### PR TITLE
Adds optional flags to specify a server, and include server details in metrics

### DIFF
--- a/collector/speedtest.go
+++ b/collector/speedtest.go
@@ -188,12 +188,13 @@ func (c *speedtestCollector) cachedOrCollect() (SpeedtestResult, error) {
 
 func (c *speedtestCollector) collect() (SpeedtestResult, error) {
 	log.Debug().Msg("running speedtest")
-	var cmd *exec.Cmd
+
+	cmdParams := []string{"--accept-license", "--accept-gdpr", "--format", "json", "--unit", "B/s"}
 	if c.serverID != "" {
-		cmd = exec.Command("speedtest", "--accept-license", "--accept-gdpr", "--format", "json", "--unit", "B/s", "-s", c.serverID)
-	} else {
-		cmd = exec.Command("speedtest", "--accept-license", "--accept-gdpr", "--format", "json", "--unit", "B/s")
+		cmdParams = append(cmdParams, "-s", c.serverID)
 	}
+
+	cmd := exec.Command("speedtest", cmdParams...)
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = os.Stderr

--- a/main.go
+++ b/main.go
@@ -16,11 +16,14 @@ import (
 
 // nolint: gochecknoglobals
 var (
-	bind     = kingpin.Flag("bind", "addr to bind the server").Short('b').Default(":9876").String()
-	debug    = kingpin.Flag("debug", "show debug logs").Default("false").Bool()
-	format   = kingpin.Flag("logFormat", "log format to use").Default("console").Enum("json", "console")
-	interval = kingpin.Flag("refresh.interval", "time between refreshes with speedtest").Default("30m").Duration()
-	version  = "master"
+	bind         = kingpin.Flag("bind", "addr to bind the server").Short('b').Default(":9876").String()
+	debug        = kingpin.Flag("debug", "show debug logs").Default("false").Bool()
+	format       = kingpin.Flag("logFormat", "log format to use").Default("console").Enum("json", "console")
+	interval     = kingpin.Flag("refresh.interval", "time between refreshes with speedtest").Default("30m").Duration()
+	server       = kingpin.Flag("server", "speedtest server id").Short('s').Default("").String()
+	serverLabels = kingpin.Flag("showServerLabels", "whether or not to annotate speedtest results with details of the server").Default("false").Bool()
+
+	version = "master"
 )
 
 func main() {
@@ -37,8 +40,22 @@ func main() {
 		log.Debug().Msg("enabled debug mode")
 	}
 
-	log.Info().Msgf("starting speedtest-exporter %s", version)
-	prometheus.MustRegister(collector.NewSpeedtestCollector(cache.New(*interval, *interval)))
+	if *server != "" {
+		log.Info().Msgf("starting speedtest-exporter %s with server %s", version, *server)
+		prometheus.MustRegister(
+			collector.NewSpeedtestCollectorWithOpts(
+				cache.New(*interval, *interval),
+				collector.SpeedtestOpts{
+					Server:           *server,
+					ShowServerLabels: *serverLabels,
+				},
+			),
+		)
+	} else {
+		log.Info().Msgf("starting speedtest-exporter %s", version)
+		prometheus.MustRegister(collector.NewSpeedtestCollector(cache.New(*interval, *interval)))
+	}
+
 	http.Handle("/metrics", promhttp.Handler())
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {

--- a/main.go
+++ b/main.go
@@ -42,19 +42,18 @@ func main() {
 
 	if *server != "" {
 		log.Info().Msgf("starting speedtest-exporter %s with server %s", version, *server)
-		prometheus.MustRegister(
-			collector.NewSpeedtestCollectorWithOpts(
-				cache.New(*interval, *interval),
-				collector.SpeedtestOpts{
-					Server:           *server,
-					ShowServerLabels: *serverLabels,
-				},
-			),
-		)
 	} else {
 		log.Info().Msgf("starting speedtest-exporter %s", version)
-		prometheus.MustRegister(collector.NewSpeedtestCollector(cache.New(*interval, *interval)))
 	}
+	prometheus.MustRegister(
+		collector.NewSpeedtestCollectorWithOpts(
+			cache.New(*interval, *interval),
+			collector.SpeedtestOpts{
+				Server:           *server,
+				ShowServerLabels: *serverLabels,
+			},
+		),
+	)
 
 	http.Handle("/metrics", promhttp.Handler())
 


### PR DESCRIPTION
`--server <ID>`, or `-s <ID>` will force the Speedtest CLI to use the
specified server. You can run `speedtest -L` to get a list of some of
your local servers.

`--showServerLabels` will include details of the server in the metrics
output. For example, without this:

```
speedtest_download_bytes 1.31984368e+08
speedtest_download_bytes_second 2.7792423e+07
```

And with:
```
speedtest_download_bytes{server_country="United Kingdom",server_host="speedtest.tnp.net.uk",server_location="Manchester",server_name="TNP Ltd."} 1.31984368e+08
speedtest_download_bytes_second{server_country="United Kingdom",server_host="speedtest.tnp.net.uk",server_location="Manchester",server_name="TNP Ltd."} 2.7792423e+07
```

Closes https://github.com/caarlos0/speedtest-exporter/issues/10