### PR TITLE
Add optional flags to bind specific network interface or ip

### DIFF
--- a/collector/speedtest.go
+++ b/collector/speedtest.go
@@ -29,6 +29,8 @@ type speedtestCollector struct {
 	packetLossPct   *prometheus.Desc
 
 	serverID         string
+	hostInterface    string
+	ip               string
 	showServerLabels bool
 }
 
@@ -41,6 +43,8 @@ func NewSpeedtestCollector(cache *cache.Cache) prometheus.Collector {
 // Use an Opts struct to enable future extensions to this if needed
 type SpeedtestOpts struct {
 	Server           string
+	Interface        string
+	Ip               string
 	ShowServerLabels bool
 }
 
@@ -115,6 +119,14 @@ func NewSpeedtestCollectorWithOpts(cache *cache.Cache, opts SpeedtestOpts) prome
 
 	if opts.Server != "" {
 		collector.serverID = opts.Server
+	}
+
+	if opts.Interface != "" {
+		collector.hostInterface = opts.Interface
+	}
+
+	if opts.Ip != "" {
+		collector.ip = opts.Ip
 	}
 
 	return collector
@@ -192,6 +204,12 @@ func (c *speedtestCollector) collect() (SpeedtestResult, error) {
 	cmdParams := []string{"--accept-license", "--accept-gdpr", "--format", "json", "--unit", "B/s"}
 	if c.serverID != "" {
 		cmdParams = append(cmdParams, "-s", c.serverID)
+	}
+	if c.hostInterface != "" {
+		cmdParams = append(cmdParams, "-I", c.hostInterface)
+	}
+	if c.ip != "" {
+		cmdParams = append(cmdParams, "-i", c.ip)
 	}
 
 	cmd := exec.Command("speedtest", cmdParams...)

--- a/main.go
+++ b/main.go
@@ -22,6 +22,8 @@ var (
 	interval     = kingpin.Flag("refresh.interval", "time between refreshes with speedtest").Default("30m").Duration()
 	server       = kingpin.Flag("server", "speedtest server id").Short('s').Default("").String()
 	serverLabels = kingpin.Flag("showServerLabels", "whether or not to annotate speedtest results with details of the server").Default("false").Bool()
+	hInterface   = kingpin.Flag("interface", "Attempt to bind to the specified interface when connecting to servers").Short('I').Default("").String()
+	ip           = kingpin.Flag("ip", "Attempt to bind to the specified IP address when connecting to servers").Short('i').Default("").String()
 
 	version = "master"
 )
@@ -50,6 +52,8 @@ func main() {
 			cache.New(*interval, *interval),
 			collector.SpeedtestOpts{
 				Server:           *server,
+				Interface:        *hInterface,
+				Ip:               *ip,
 				ShowServerLabels: *serverLabels,
 			},
 		),


### PR DESCRIPTION
I have multiple network interfaces with different configurations and I'd love to use this exporter to monitor each
`speedtest` already allow to specify a specific interface/ip so I've just passed the flags through

```bash
-I, --interface=""          Attempt to bind to the specified interface when connecting to servers
-i, --ip=""                 Attempt to bind to the specified IP address when connecting to servers
```