### PR TITLE
docs: remove starchart.cc embed

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,3 @@ Download the `.apk`, `.deb` or `.rpm` from the [releases page][releases] and ins
 Download the pre-compiled binaries from the [releases page][releases] or clone the repo build from source.
 
 [releases]: https://github.com/caarlos0/speedtest-exporter/releases
-
-## Stargazers over time
-
-[![Stargazers over time](https://starchart.cc/caarlos0/speedtest-exporter.svg)](https://starchart.cc/caarlos0/speedtest-exporter)


### PR DESCRIPTION
`starchart.cc` is rate limited and rendering a broken image in the README, so this removes the embed and its (now-empty) stargazers section.

Refs: https://github.com/caarlos0/starcharts/issues/260
